### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ see also
 source dependency
 ========
 * Cjson: https://github.com/kbranigan/cJSON
-* http-parser: https://github.com/joyent/http-parser
+* http-parser: https://github.com/nodejs/http-parser
 
 [back to toc](#table-of-contents)
 


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/joyent/http-parser | https://github.com/nodejs/http-parser 
