### PR TITLE
Fix weights not being properly reset

### DIFF
--- a/src/ngx_http_upsync_module.c
+++ b/src/ngx_http_upsync_module.c
@@ -1128,6 +1128,8 @@ ngx_http_upsync_update_peers(ngx_cycle_t *cycle,
                 peers->peer[i].fail_timeout = upstream_conf->fail_timeout;
                 peers->peer[i].down = upstream_conf->down;
                 peers->peer[i].weight = upstream_conf->weight;
+		peers->peer[i].effective_weight = upstream_conf->weight;
+		peers->peer[i].current_weight = 0;
 
                 w += upstream_conf->weight;
 

--- a/src/ngx_http_upsync_module.c
+++ b/src/ngx_http_upsync_module.c
@@ -1128,8 +1128,8 @@ ngx_http_upsync_update_peers(ngx_cycle_t *cycle,
                 peers->peer[i].fail_timeout = upstream_conf->fail_timeout;
                 peers->peer[i].down = upstream_conf->down;
                 peers->peer[i].weight = upstream_conf->weight;
-		peers->peer[i].effective_weight = upstream_conf->weight;
-		peers->peer[i].current_weight = 0;
+                peers->peer[i].effective_weight = upstream_conf->weight;
+                peers->peer[i].current_weight = 0;
 
                 w += upstream_conf->weight;
 


### PR DESCRIPTION
Hi,
in our testing in our environment we have noticed that when you lower weights from let's say 3:1 to 1:1 it does not properly rebalance the weights. This fixes the problem.

Signed-off-by: Ashley Moravek <ashley@victorianfox.com>