### PR TITLE
Temporary ignore backup flag  to prevent server crashing on backup nodes

### DIFF
--- a/src/ngx_http_upsync_module.c
+++ b/src/ngx_http_upsync_module.c
@@ -796,9 +796,12 @@ ngx_http_upsync_add_peers(ngx_cycle_t *cycle,
         for (i = 0; i < servers->nelts; i++) {
 
             server = (ngx_http_upstream_server_t *)servers->elts + i;
-            if (server->backup) {
-                continue;
-            }
+            //if (server->backup) {
+            //    continue;
+            //}
+            //
+            // FIXME: until backup is fully implemented this causes crashes
+            //        on startup with nodes set backup=1. Let them in for now
 
             peers->peer[m].sockaddr = server->addrs->sockaddr;
             peers->peer[m].socklen = server->addrs->socklen;


### PR DESCRIPTION
As discussed in issue #29 previously, this temporarily ignores the backup flag check and prevents random crash on startup.

Signed-off-by: Ashley Moravek <ashley@victorianfox.com>