### PR TITLE
Fix list upstreams when no upstreams were defined

### DIFF
--- a/src/ngx_http_upsync_module.c
+++ b/src/ngx_http_upsync_module.c
@@ -3758,6 +3758,13 @@ ngx_http_upsync_show(ngx_http_request_t *r)
 
     host = &r->args;
     if (host->len == 0 || host->data == NULL) {
+
+        if (umcf->upstreams.nelts == 0) {
+            b->last = ngx_snprintf(b->last, b->end - b->last,
+                                   "No upstreams defined");
+
+            goto end;
+        }
     	
     	for (i = 0; i < umcf->upstreams.nelts; i++) {
             ngx_http_upsync_show_upstream(uscfp[i], b);


### PR DESCRIPTION
Prevents error page shown when trying to list all upstreams but no upstreams were defined as reported in #46

Signed-off-by: Ashley Moravek <ashley@victorianfox.com>