### PR TITLE
Fix etcd timing out if index changes too much compared to waitIndex

### DIFF
--- a/src/ngx_http_upsync_module.c
+++ b/src/ngx_http_upsync_module.c
@@ -2548,10 +2548,9 @@ ngx_http_upsync_send_handler(ngx_event_t *event)
 
     if (upsync_type_conf->upsync_type == NGX_HTTP_UPSYNC_ETCD) {
         if (upsync_server->index != 0) {
-            ngx_sprintf(request, "GET %V?wait=true&recursive=true&waitIndex=%d" 
+            ngx_sprintf(request, "GET %V?wait=true&recursive=true"
                         " HTTP/1.0\r\nHost: %V\r\n Accept: */*\r\n\r\n", 
-                        &upscf->upsync_send, upsync_server->index,
-                        &upscf->conf_server.name);
+                        &upscf->upsync_send, &upscf->conf_server.name);
 
         } else {
             ngx_sprintf(request, "GET %V?" 


### PR DESCRIPTION
Fixes #59 - if ETCD index changes beyond some amount since the current waitIndex, it starts returning error code 401. This removes the waitIndex as the code rescans the whole upstream on a change anyways.

Signed-off-by: Ashley <ashley@victorianfox.com>