### PR TITLE
fix for worker dying issue when returned keys contain no slash

### DIFF
--- a/src/ngx_http_upsync_module.c
+++ b/src/ngx_http_upsync_module.c
@@ -1183,7 +1183,7 @@ ngx_http_upsync_consul_parse_json(void *data)
         cJSON *temp1 = cJSON_GetObjectItem(server_next, "Key");
         if (temp1 != NULL && temp1->valuestring != NULL) {
             p = (u_char *)ngx_strrchr(temp1->valuestring, '/');
-            if (ngx_http_upsync_check_key(p) != NGX_OK) {
+            if (p == NULL || ngx_http_upsync_check_key(p) != NGX_OK) {
                 continue;
             }
 


### PR DESCRIPTION
@xiaokai-wang would you please merge this into nginx-upsync-1.9.x branch as well? We are using nginx 1.10.0 Thanks.