### PR TITLE
Fix extra space before Accept in ETCD

### DIFF
--- a/src/ngx_http_upsync_module.c
+++ b/src/ngx_http_upsync_module.c
@@ -2559,12 +2559,12 @@ ngx_http_upsync_send_handler(ngx_event_t *event)
     if (upsync_type_conf->upsync_type == NGX_HTTP_UPSYNC_ETCD) {
         if (upsync_server->index != 0) {
             ngx_sprintf(request, "GET %V?wait=true&recursive=true"
-                        " HTTP/1.0\r\nHost: %V\r\n Accept: */*\r\n\r\n", 
+                        " HTTP/1.0\r\nHost: %V\r\nAccept: */*\r\n\r\n", 
                         &upscf->upsync_send, &upscf->conf_server.name);
 
         } else {
             ngx_sprintf(request, "GET %V?" 
-                        " HTTP/1.0\r\nHost: %V\r\n Accept: */*\r\n\r\n", 
+                        " HTTP/1.0\r\nHost: %V\r\nAccept: */*\r\n\r\n", 
                         &upscf->upsync_send, &upscf->conf_server.name);
 
         }


### PR DESCRIPTION
It was sending HTTP headers in the form of
GET /v2/keys/upstreams/devjessie? HTTP/1.0
Host: 127.0.0.1:2379
 Accept: */*


 .. which had only this reply ... no idea how it worked until now though?

HTTP/1.1 400 Bad Request
Content-Type: text/plain
Connection: close

400 Bad Request: malformed Host header

This PR removes the extra space in front of Accept.