### PR TITLE
Revert to waitIndex in ETCD and add support for expired waitIndex

### DIFF
--- a/src/ngx_http_upsync_module.c
+++ b/src/ngx_http_upsync_module.c
@@ -2570,9 +2570,10 @@ ngx_http_upsync_send_handler(ngx_event_t *event)
 
     if (upsync_type_conf->upsync_type == NGX_HTTP_UPSYNC_ETCD) {
         if (upsync_server->index != 0) {
-            ngx_sprintf(request, "GET %V?wait=true&recursive=true"
+            ngx_sprintf(request, "GET %V?wait=true&recursive=true&waitIndex=%d"
                         " HTTP/1.0\r\nHost: %V\r\nAccept: */*\r\n\r\n", 
-                        &upscf->upsync_send, &upscf->conf_server.name);
+                        &upscf->upsync_send, upsync_server->index, 
+                        &upscf->conf_server.name);
 
         } else {
             ngx_sprintf(request, "GET %V?" 

--- a/src/ngx_http_upsync_module.c
+++ b/src/ngx_http_upsync_module.c
@@ -205,7 +205,7 @@ static void ngx_http_upsync_event_init(ngx_http_upstream_rr_peers_t *tmp_peers,
     ngx_http_upsync_server_t *upsync_server, ngx_flag_t flag);
 
 static ngx_int_t ngx_http_parser_init();
-static void ngx_http_parser_execute(ngx_http_upsync_ctx_t *ctx);
+static void ngx_http_parser_execute(ngx_http_upsync_ctx_t *ctx, ngx_upsync_conf_t *upsync_type_conf);
 
 static int ngx_http_status(http_parser *p, const char *buf, size_t len);
 static int ngx_http_header_field_cb(http_parser *p, const char *buf, 
@@ -2753,7 +2753,7 @@ ngx_http_upsync_parse_init(void *data)
             return NGX_ERROR;
         }
 
-        ngx_http_parser_execute(ctx);
+        ngx_http_parser_execute(ctx, upsync_type_conf);
         if (ctx->body.pos != ctx->body.last) {
             *(ctx->body.last + 1) = '\0';
 
@@ -3218,7 +3218,7 @@ ngx_http_parser_init()
 
 
 static void
-ngx_http_parser_execute(ngx_http_upsync_ctx_t *ctx)
+ngx_http_parser_execute(ngx_http_upsync_ctx_t *ctx, ngx_upsync_conf_t *upsync_type_conf)
 {
     char      *buf;
     size_t     parsed;
@@ -3235,7 +3235,8 @@ ngx_http_parser_execute(ngx_http_upsync_ctx_t *ctx)
     }
 
     if (ngx_strncmp(state.status, "OK", 2) == 0 
-            || ngx_strncmp(state.status, "Bad", 3) == 0) {
+            || (ngx_strncmp(state.status, "Bad", 3) == 0 &&
+                    upsync_type_conf->upsync_type == NGX_HTTP_UPSYNC_ETCD)) {
 
         if (ngx_strlen(state.http_body) != 0) {
             ctx->body.pos = state.http_body;

--- a/src/ngx_http_upsync_module.c
+++ b/src/ngx_http_upsync_module.c
@@ -2757,7 +2757,7 @@ ngx_http_upsync_consul_parse_init(void *data)
     parsed = http_parser_execute(parser, &settings, buf, ngx_strlen(buf));
     if (parsed != ngx_strlen(buf)) {
         ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, 0,
-                      "http_parser_execute: parsed body size is wrong");
+                      "upsync_consul_parse_init: parsed body size is wrong");
         return NGX_ERROR;
     }
 
@@ -2806,7 +2806,7 @@ ngx_http_upsync_etcd_parse_init(void *data)
     parsed = http_parser_execute(parser, &settings, buf, ngx_strlen(buf));
     if (parsed != ngx_strlen(buf)) {
         ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, 0,
-                      "http_parser_execute: parsed body size is wrong");
+                      "upsync_etcd_parse_init: parsed body size is wrong");
         return NGX_ERROR;
     }
 


### PR DESCRIPTION
As discussed in #71 - this passes 400 Bad Request to the JSON handler, which can detect when waitIndex expires and does a full refresh to load the new index.

Please, before you pull it, test it with Consul -- as I pass 400 Bad Request to the JSON parser to check the status code! We do not have any Consul backend, cannot test it myself sadly.

Tested overnight, server stayed in sync and did not time out on waitIndex like it used to, plus changing 3 nodes at once worked fine in the morning, it would previously update either one or two at most (depending on the speed of the server).

Signed-off-by: Ashley Moravek <ashley@victorianfox.com>