### PR TITLE
new upsync type consul_services

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Data can be taken from key/value store or service catalog. In the first case par
         upsync 127.0.0.1:8500/v1/kv/upstreams/test upsync_timeout=6m upsync_interval=500ms upsync_type=consul strong_dependency=off;
 ```
 
-In the second case it mast be *consul_services*.
+In the second case it must be *consul_services*.
 
 ```nginx-consul
         upsync 127.0.0.1:8500/v1/catalog/service/test upsync_timeout=6m upsync_interval=500ms upsync_type=consul_services strong_dependency=off;

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Name
 ====
 
-nginx-upsync-module - Nginx C module, sync upstreams from consul or others, dynamiclly modify backend-servers attribute(weight, max_fails,...), needn't reload nginx.
+nginx-upsync-module - Nginx C module, sync upstreams from consul or others, dynamically modify backend-servers attribute(weight, max_fails,...), needn't reload nginx.
 
 It may not always be convenient to modify configuration files and restart NGINX. For example, if you are experiencing large amounts of traffic and high load, restarting NGINX and reloading the configuration at that point further increases load on the system and can temporarily degrade performance.
 
@@ -16,7 +16,7 @@ Table of Contents
 * [Status](#status)
 * [Synopsis](#synopsis)
 * [Description](#description)
-* [Directives](#functions)
+* [Directives](#directives)
     * [upsync](#upsync)
         * [upsync_interval](#upsync_interval)
         * [upsync_timeout](#upsync_timeout)
@@ -153,7 +153,7 @@ http {
 Description
 ======
 
-This module provides a method to discover backend servers. Supporting dynamicly adding or deleting backend server through consul and dynamicly adjusting backend servers weight, module will timely pull new backend server list from consul to upsync nginx ip router. Nginx needn't reload. Having some advantages than others:
+This module provides a method to discover backend servers. Supporting dynamicly adding or deleting backend server through consul and dynamically adjusting backend servers weight, module will timely pull new backend server list from consul to upsync nginx ip router. Nginx needn't reload. Having some advantages than others:
 
 * timely
 
@@ -165,13 +165,13 @@ This module provides a method to discover backend servers. Supporting dynamicly 
 
 * stability
 
-      Even if one pulling failed, it will pull next upsync_interval, so guaranteing backend server stably provides service. And support dumping the latest config to location, so even if consul hung up, and nginx can be reload anytime. 
+      Even if one pulling failed, it will pull next upsync_interval, so guarantying backend server stably provides service. And support dumping the latest config to location, so even if consul hung up, and nginx can be reload anytime. 
 
 * health_check
 
       nginx-upsync-module support adding or deleting servers health check, needing nginx_upstream_check_module. Recommending nginx-upsync-module + nginx_upstream_check_module.
 
-Diretives
+Directives
 ======
 
 upsync
@@ -260,7 +260,19 @@ show all upstreams.
 Consul_interface
 ======
 
-you can add or delete backend server through consul_ui or http_interface.
+Data can be taken from key/value store or service catalog. In the first case parameter upsync_type of directive must be *consul*. For example
+
+```nginx-consul
+        upsync 127.0.0.1:8500/v1/kv/upstreams/test upsync_timeout=6m upsync_interval=500ms upsync_type=consul strong_dependency=off;
+```
+
+In the second case it mast be *consul_services*.
+
+```nginx-consul
+        upsync 127.0.0.1:8500/v1/catalog/service/test upsync_timeout=6m upsync_interval=500ms upsync_type=consul_services strong_dependency=off;
+```
+
+You can add or delete backend server through consul_ui or http_interface. Below are examples for key/value store.
 
 http_interface example:
 

--- a/src/ngx_http_upsync_module.c
+++ b/src/ngx_http_upsync_module.c
@@ -1458,9 +1458,7 @@ ngx_http_upsync_consul_services_parse_json(void *data)
             if (ngx_strncmp(tag, "weight=", 7) == 0) {
                 attr_value = ngx_atoi(tag + 7, (size_t)ngx_strlen(tag) - 7);
 
-                if (attr_value == NGX_ERROR) {
-                    continue; 
-                } else if (attr_value <= 0) {
+                if (attr_value == NGX_ERROR || attr_value <= 0) {
                     ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, 0,
                           "upsync_parse_json: \"weight\" value is invalid"
                           ", setting default value 1");
@@ -1472,9 +1470,7 @@ ngx_http_upsync_consul_services_parse_json(void *data)
             if (ngx_strncmp(tag, "max_fails=", 10) == 0) {
                 attr_value = ngx_atoi(tag + 10, (size_t)ngx_strlen(tag) - 10);
 
-                if (attr_value == NGX_ERROR) {
-                    continue; 
-                } else if (attr_value < 0) {
+                if (attr_value == NGX_ERROR || attr_value < 0) {
                     ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, 0,
                           "upsync_parse_json: \"max_fails\" value is invalid"
                           ", setting default value 2");
@@ -1487,9 +1483,7 @@ ngx_http_upsync_consul_services_parse_json(void *data)
                 ngx_str_t  value = {ngx_strlen(tag) - 13, tag + 13};
                 attr_value = ngx_parse_time(&value, 0);
 
-                if (attr_value == NGX_ERROR) {
-                    continue; 
-                } else if (attr_value < 0) {
+                if (attr_value == NGX_ERROR || attr_value < 0) {
                     ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, 0,
                           "upsync_parse_json: \"fail_timeout\" value is invalid"
                           ", setting default value 10");

--- a/src/ngx_http_upsync_module.c
+++ b/src/ngx_http_upsync_module.c
@@ -1431,6 +1431,7 @@ ngx_http_upsync_consul_services_parse_json(void *data)
 
         upstream_conf = ngx_array_push(&ctx->upstream_conf);
         if (upstream_conf == NULL) {
+            cJSON_Delete(root);
             return NGX_ERROR;
         }
         ngx_memzero(upstream_conf, sizeof(*upstream_conf));
@@ -1464,8 +1465,8 @@ ngx_http_upsync_consul_services_parse_json(void *data)
 
                 if (attr_value == NGX_ERROR || attr_value <= 0) {
                     ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, 0,
-                          "upsync_parse_json: \"weight\" value is invalid"
-                          ", setting default value 1");
+                                  "upsync_parse_json: \"weight\" value is "
+                                  "invalid, setting default value 1");
                     continue; 
                 } else {
                     upstream_conf->weight = attr_value;
@@ -1476,8 +1477,8 @@ ngx_http_upsync_consul_services_parse_json(void *data)
 
                 if (attr_value == NGX_ERROR || attr_value < 0) {
                     ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, 0,
-                          "upsync_parse_json: \"max_fails\" value is invalid"
-                          ", setting default value 2");
+                                  "upsync_parse_json: \"max_fails\" value is "
+                                  "invalid, setting default value 2");
                     continue; 
                 } else {
                     upstream_conf->max_fails = attr_value;
@@ -1489,8 +1490,8 @@ ngx_http_upsync_consul_services_parse_json(void *data)
 
                 if (attr_value == NGX_ERROR || attr_value < 0) {
                     ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, 0,
-                          "upsync_parse_json: \"fail_timeout\" value is invalid"
-                          ", setting default value 10");
+                                  "upsync_parse_json: \"fail_timeout\" value is "
+                                  "invalid, setting default value 10");
                     continue; 
                 } else {
                     upstream_conf->fail_timeout = attr_value;

--- a/src/ngx_http_upsync_module.c
+++ b/src/ngx_http_upsync_module.c
@@ -1399,7 +1399,7 @@ ngx_http_upsync_consul_services_parse_json(void *data)
         cJSON *addr = cJSON_GetObjectItem(server_next, "ServiceAddress");
         cJSON *port = cJSON_GetObjectItem(server_next, "ServicePort");
         size_t addr_len, port_len;
-        char buf[8];
+        char port_buf[8];
 
         if (addr == NULL || addr->valuestring == NULL
             || addr->valuestring[0] == '\0')
@@ -1412,11 +1412,11 @@ ngx_http_upsync_consul_services_parse_json(void *data)
         if (port == NULL || port->valueint < 1 || port->valueint > 65535) {
             continue;
         }
-        ngx_memzero(buf, 8);
-        ngx_sprintf(buf, "%d", port->valueint);
+        ngx_memzero(port_buf, 8);
+        ngx_sprintf(port_buf, "%d", port->valueint);
 
         addr_len = ngx_strlen(addr->valuestring);
-        port_len = ngx_strlen(buf);
+        port_len = ngx_strlen(port_buf);
 
         if (addr_len + port_len + 2 > NGX_SOCKADDRLEN) {
             continue;
@@ -1430,7 +1430,7 @@ ngx_http_upsync_consul_services_parse_json(void *data)
 
         ngx_memcpy(upstream_conf->sockaddr, addr->valuestring, addr_len);
         ngx_memcpy(upstream_conf->sockaddr + addr_len, ":", 1);
-        ngx_memcpy(upstream_conf->sockaddr + addr_len + 1, buf, port_len);
+        ngx_memcpy(upstream_conf->sockaddr + addr_len + 1, port_buf, port_len);
 
         /* default server attributes */
         upstream_conf->weight = 1;

--- a/src/ngx_http_upsync_module.c
+++ b/src/ngx_http_upsync_module.c
@@ -1481,7 +1481,7 @@ ngx_http_upsync_consul_services_parse_json(void *data)
             }
             if (ngx_strncmp(tag, "fail_timeout=", 13) == 0) {
                 ngx_str_t  value = {ngx_strlen(tag) - 13, tag + 13};
-                attr_value = ngx_parse_time(&value, 0);
+                attr_value = ngx_parse_time(&value, 1);
 
                 if (attr_value == NGX_ERROR || attr_value < 0) {
                     ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, 0,

--- a/src/ngx_http_upsync_module.c
+++ b/src/ngx_http_upsync_module.c
@@ -1210,6 +1210,10 @@ ngx_http_upsync_consul_parse_json(void *data)
         }
         temp1 = NULL;
 
+        if (upstream_conf == NULL) {
+            continue;
+        }
+
         temp1 = cJSON_GetObjectItem(server_next, "Value");
         if (temp1 != NULL && temp1->valuestring != NULL) {
 

--- a/src/ngx_http_upsync_module.c
+++ b/src/ngx_http_upsync_module.c
@@ -1444,6 +1444,10 @@ ngx_http_upsync_consul_services_parse_json(void *data)
         upstream_conf->backup = 0;
 
         tags = cJSON_GetObjectItem(server_next, "ServiceTags");
+        if (tags == NULL) {
+            continue;
+        }
+
         for (tag_next = tags->child; tag_next != NULL; 
              tag_next = tag_next->next) 
         {

--- a/src/ngx_http_upsync_module.c
+++ b/src/ngx_http_upsync_module.c
@@ -1375,8 +1375,6 @@ ngx_http_upsync_consul_services_parse_json(void *data)
 
     ctx = &upsync_server->ctx;
     buf = &ctx->body;
-        ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, 0,
-                      "buf: %s", buf->pos);
 
     cJSON *root = cJSON_Parse((char *)buf->pos);
     if (root == NULL) {

--- a/src/ngx_http_upsync_module.h
+++ b/src/ngx_http_upsync_module.h
@@ -19,11 +19,11 @@
 #define ngx_strtoull(nptr, endptr, base) strtoull((const char *) nptr, \
                                                   (char **) endptr, (int) base)
 
-#define NGX_INDEX_HEARDER "X-Consul-Index"
-#define NGX_INDEX_HEARDER_LEN 14
+#define NGX_INDEX_HEADER "X-Consul-Index"
+#define NGX_INDEX_HEADER_LEN 14
 
-#define NGX_INDEX_ETCD_HEARDER "X-Etcd-Index"
-#define NGX_INDEX_ETCD_HEARDER_LEN 12
+#define NGX_INDEX_ETCD_HEADER "X-Etcd-Index"
+#define NGX_INDEX_ETCD_HEADER_LEN 12
 
 #define NGX_MAX_HEADERS 20
 #define NGX_MAX_ELEMENT_SIZE 512


### PR DESCRIPTION
This commit makes possible to get upstreams from the Consul services catalog. For testing I used the following Consul config:

```json
{
    "server": true,
    "node_name": "test",
    "bind_addr": "127.0.0.1",
    "data_dir": "/var/lib/consul",
    "log_level": "INFO",
    "service": {"name": "test",
                "port": 8081}
}
```

and Nginx config (it requires nginx *echo* module), notice that `upsync_type` is `consul_services`:

```nginx
user                    nobody;
worker_processes        2;

events {
    worker_connections  1024;
}

http {
    upstream test {
        # fake server otherwise ngx_http_upstream will report error when startup
        server 127.0.0.1:11111;

        # all backend server will pull from consul when startup and will delete fake server
        upsync 127.0.0.1:8500/v1/catalog/service/test
                upsync_timeout=6m
                upsync_interval=500ms
                upsync_type=consul_services
                strong_dependency=off;
        #upsync_dump_path /usr/local/nginx/conf/servers/servers_test.conf;
        upsync_dump_path /tmp/servers_test.conf;
    }

    server {
        listen 8080;

        location = /proxy_test {
            proxy_pass http://test;
        }

        location = /upstream_show {
            upstream_show;
        }
    }

    server {
        listen 8081;

        location / {
            echo "In 8081";
        }
    }
}
```

The arguable solutions are:

1. All servers have default hard-coded values for `max_fails`, `fail_timeout` and other server-specific parameters as there is no data available from services catalog to map to them. Some of the parameters (like `backup` or `down`) cannot be figured out at all, but `max_fails` and `fail_timeout` can be set statically on per-upstream basis using dedicated directives like `upsync_consul_services_max_fails` and `upsync_consul_services_fail_timeout` - they are not implemented here but it's easy to do.
2. If `NGX_HTTP_UPSYNC_CONSUL` and others are planned to be used in bit operations then their values must be `0x0001`, `0x0002` and `0x0004` instead of current 1 to 3. Also I put the new value `NGX_HTTP_UPSYNC_CONSUL_SERVICES` on the 2nd place (`0x0002`).
3. I have not changed the request URI for the services catalog and it includes parameter `recurse`: this is not needed by Consul but seems to be harmless.