### PR TITLE
Fix buffer overflow error

### DIFF
--- a/src/ngx_http_upsync_module.c
+++ b/src/ngx_http_upsync_module.c
@@ -801,7 +801,7 @@ ngx_http_upsync_add_peers(ngx_cycle_t *cycle,
             goto invalid;
         }
         ngx_memcpy(peers, tmp_peers, sizeof(ngx_http_upstream_rr_peers_t) +
-                   + sizeof(ngx_http_upstream_rr_peer_t) * (tmp_peers->number));
+                   + sizeof(ngx_http_upstream_rr_peer_t) * (tmp_peers->number - 1));
 
         m = tmp_peers->number;
         for (i = 0; i < servers->nelts; i++) {


### PR DESCRIPTION
When peers are added to upstream, a buffer overflow occurs. Uninitialized data fields (such as fails field of struct ngx_http_upstream_rr_peer_s) are written to the system and affect the selection of the round robin algorithm, resulting in unbalanced traffic.