### PR TITLE
Adding support for consul service health endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,14 @@ In the second case it must be *consul_services*.
         upsync 127.0.0.1:8500/v1/catalog/service/test upsync_timeout=6m upsync_interval=500ms upsync_type=consul_services strong_dependency=off;
 ```
 
+In the third case, it must be *consul_health*:
+
+```nginx-consul
+        upsync 127.0.0.1:8500/v1/health/service/test upsync_timeout=6m upsync_interval=500ms upsync_type=consul_health strong_dependency=off;
+```
+
+Services with failing health checks are marked as down with the health api.
+
 You can add or delete backend server through consul_ui or http_interface. Below are examples for key/value store.
 
 http_interface example:

--- a/src/ngx_http_upsync_module.c
+++ b/src/ngx_http_upsync_module.c
@@ -1681,19 +1681,20 @@ ngx_http_upsync_consul_health_parse_json(void *data)
     for (server_next = root->child; server_next != NULL;
          server_next = server_next->next)
     {
-        cJSON *addr, *checks, *check_next, *port, *service, *tags, *tag_next;
+        cJSON *addr, *checks, *check_next, *node, *port, *service, *tags, *tag_next;
         size_t addr_len, port_len;
         u_char port_buf[8];
 
+        node = cJSON_GetObjectItem(server_next, "Node");
 
-        service = cJSON_GetObjectItem(server_next, "Service");
-
-        addr = cJSON_GetObjectItem(service, "Address");
+        addr = cJSON_GetObjectItem(node, "Address");
         if (addr == NULL || addr->valuestring == NULL
             || addr->valuestring[0] == '\0')
         {
             continue;
         }
+
+        service = cJSON_GetObjectItem(server_next, "Service");
 
         port = cJSON_GetObjectItem(service, "Port");
         if (port == NULL || port->valueint < 1 || port->valueint > 65535) {
@@ -1741,6 +1742,7 @@ ngx_http_upsync_consul_health_parse_json(void *data)
                 || ngx_strncmp(check_status->valuestring, "passing", 7) != 0)
             {
               upstream_conf->down = 1;
+              break;
             }
         }
 


### PR DESCRIPTION
Consul does not filter results by the health status of checks over the catalog interface, which is used with _consul_services_. The consul health endpoint for services, which includes the health status of checks, allows for health filtering.

I made a few edits to ngx_http_upsync_consul_services_parse_json to support the health interface and added it as a new upsync_type.