### PR TITLE
bugfix for tmp_del_peer

### DIFF
--- a/src/ngx_http_upsync_module.c
+++ b/src/ngx_http_upsync_module.c
@@ -1153,7 +1153,10 @@ ngx_http_upsync_del_peers(ngx_cycle_t *cycle,
             pre_peer = peer;
         }
     }
-    tmp_del_peer->next = NULL;
+
+    if (tmp_del_peer) {
+        tmp_del_peer->next = NULL;
+    }
 
     peers->single = (n == 1);
     peers->number = n;


### PR DESCRIPTION
 the variable tmp_del_peer may not be setted before used.   when no same peer find, tmp_del_peer  is a Null pointer